### PR TITLE
Update Raven(legacy) Sentry dependency to the latest version

### DIFF
--- a/lib/Log.js
+++ b/lib/Log.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const raven = require('raven');
+const Raven = require('raven');
 
 class Log {
 
@@ -38,10 +38,8 @@ class Log {
 		if( process.env.DEBUG === '1' && this._homey.env.HOMEY_LOG_FORCE !== '1' )
 			return this._log('App is running in debug mode, disabling log');
 
-		this._client = new raven.Client( url, opts );
+		Raven.config(url, opts).install();
 
-		this._client.patchGlobal();
-		
 		this.setTags({
 			appId			: this._homey.manifest.id,
 			appVersion		: this._homey.manifest.version,
@@ -67,27 +65,34 @@ class Log {
 	}
 
 	setTags( tags ) {
-		if( this._client ) {
-			this._client.setTagsContext(tags);
-		}
+		this._mergeContext('tags', tags)
 
 		return this;
 	}
 
 	setExtra( extra ) {
-		if( this._client ) {
-			this._client.setExtraContext(extra);
-		}
+		this._mergeContext('extra', extra);
 
 		return this;
 	}
 
 	setUser( user ) {
-		if( this._client ) {
-			this._client.setUserContext(user);
-		}
+		this._mergeContext('user', user);
 
 		return this;
+	}
+
+	_mergeContext(key, value) {
+		// Raven.mergeContext covers only 1-level of the context (tags, extra, user)
+		// We need to merge a 2-level of the context
+		// see https://github.com/getsentry/raven-node/issues/228
+		const context = Raven.getContext();
+		if (!context[key]) {
+			context[key] = {}
+		}
+
+		Object.assign(context[key], value)
+		Raven.setContext(context);
 	}
 
 	captureMessage( message, options, callback) {
@@ -100,13 +105,11 @@ class Log {
 
 		this._capturedMessages.push( message )
 
-		if( this._client ) {
-			this._client.captureMessage(
-				message,
-				options && options.constructor.name === 'Object' ? Object.assign({}, options) : options,
-				callback
-			);
-		}
+		Raven.captureMessage(
+			message,
+			options && options.constructor.name === 'Object' ? Object.assign({}, options) : options,
+			callback
+		);
 
 		return this;
 	}
@@ -121,13 +124,11 @@ class Log {
 
 		this._capturedExceptions.push( err )
 
-		if( this._client ) {
-			this._client.captureException(
-				err,
-				options && options.constructor.name === 'Object' ? Object.assign({}, options) : options,
-				callback
-			);
-		}
+		Raven.captureException(
+			err,
+			options && options.constructor.name === 'Object' ? Object.assign({}, options) : options,
+			callback
+		);
 
 		return this;
 	}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://WeeJewel@github.com/athombv/node-homey-log.git"
+    "url": "git+https://github.com/athombv/node-homey-log.git"
   },
   "author": "",
   "license": "ISC",
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/athombv/node-homey-log#readme",
   "dependencies": {
-    "raven": "^0.12.3"
+    "raven": "^2.6.4"
   },
   "config": {
     "npmPublishTagProduction": "latest",


### PR DESCRIPTION
Hello.

This module uses sentry dependency that called `raven` and it has version constraint to  `^0.12.3`. This version was release in 11.2016.

This PR updates `raven` dependency to the latest version `2.6.4` which was released in 09.2018.

`Raven` is a legacy Node.js package for Sentry.

Nowadays Sentry provides a new [@sentry/node](https://www.npmjs.com/package/@sentry/node) package which can be used, but it increases app size on around 4.5Mb. 

I've made a [PoC branch](https://github.com/aivus/node-homey-log/tree/upgrade_sentry) for this package as well, but didn't finish it due to mentioned above.

I decided to just prepare PR for the updating Raven which is more lightweight.

@RobinBol will you be able to look on this PR?