### PR TITLE
Added details on getting Sentry URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ npm install --save homey-log
 
 ## Getting started
 
-In `env.json`, add the Sentry URL. If you would like to send the logs to Sentry *also* during development, set force log to `1`.
+In `env.json`, add the Sentry URL. The Sentry URL is found in your project settings, and is denoted [DSN](https://docs.sentry.io/platforms/node).  
+If you would like to send the logs to Sentry *also* during development, set force log to `1`.
 
 ```json
 {
@@ -47,7 +48,7 @@ class MyApp extends Homey.App {
 ### Notes
 
 * When your app crashes due to an `uncaughtException` or `unhandledRejection`, this will automatically be sent to Sentry.
-* When running your app with `homey app run` events will not be sent to Sentry.
+* When running your app with `homey app run` events will not be sent to Sentry, unless you set `HOMEY_LOG_FORCE` to `1`.
 
 ## Changelog
 ### 2.0.0


### PR DESCRIPTION
Because someone opened an issue (#43) on where to retrieve the Sentry URL, and also I was not sure to begin with. I figured a sentence to clear that up was in place. 

Also clarified that logging actually will be enabled when debugging (homey app run) if the HOMEY_LOG_FORCE variable is set.